### PR TITLE
:children_crossing: fix - Changed the header element from a div to a …

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -2,13 +2,13 @@ import "./Header.css";
 
 const Header = ({ links }) => {
   return (
-    <div id='header'>
+    <head id='header'>
       {links.map((linkTitle, index) => (
         <a key={`${linkTitle}_pos_${index}`} href=''>
           {linkTitle}
         </a>
       ))}
-    </div>
+    </head>
   );
 };
 


### PR DESCRIPTION
# Usability
In the first version the header of the website had a `div` for tag, now it was changed to a `head` for usability purposes.